### PR TITLE
First draft of build-and-push action

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 
 ### Build information
 
-| Input Name       | Description                                                     | Default value |
-|------------------|-----------------------------------------------------------------|---------------|
-| `version `       | Version of the built image.                                     | **required**  |
-| `tag`            | Tag of the built image.                                         | **required**  |
-| `dockerfile`     | Dockerfile to build the image.                                  | Dockerfile    |
-| `use_distgen`    | The action will use distgen for generating dockerfiles if true. | false         |
-| `docker_context' | Docker build context.                                           | .             |
+| Input Name       | Description                                                         | Default value |
+|------------------|---------------------------------------------------------------------|---------------|
+| `version `       | Version of the primary application contained in the container image. It is also used as a relative path to a specified `dockerfile` in the container's repository. | **required**  |
+| `tag`            | Tag of the built image.                                             | **required**  |
+| `dockerfile`     | Dockerfile to build the image.                                      | Dockerfile    |
+| `use_distgen`    | The action will use distgen for generating dockerfiles if true.     | false         |
+| `docker_context' | Docker build context.                                               | .             |
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-# build-and-push-action
+# The Build and Push GitHub Action
+
+## Action Inputs
+
+### Registry information
+
+| Input Name           | Description                                                 | Default value |
+|----------------------|-------------------------------------------------------------|---------------|
+| `registry`           | Registry to push container image to.                        | **required**  |
+| `registry_namespace` | Namespace of the registry, where the image would be pushed. | **required**  |
+| `registry_username`  | Login to specified registry.                                | **required**  |
+| `registry_token`     | Access token to specified registry.                         | **required**  |
+
+### Build information
+
+| Input Name       | Description                                                     | Default value |
+|------------------|-----------------------------------------------------------------|---------------|
+| `version `       | Version of the built image.                                     | **required**  |
+| `tag`            | Tag of the built image.                                         | **required**  |
+| `dockerfile`     | Dockerfile to build the image.                                  | Dockerfile    |
+| `use_distgen`    | The action will use distgen for generating dockerfiles if true. | false         |
+| `docker_context' | Docker build context.                                           | .             |
+
+
+
+## Example
+
+The example below shows how the `sclorg/build-and-push-action` can be used.
+
+```yaml
+name: Build and push to quay.io registry
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Build and push to quay.io registry
+        uses: sclorg/build-and-push-action@v1
+        with:
+          registry: "quay.io"
+          registry_namespace: "sclorg"
+          registry_username: ${{ secrets.REGISTRY_LOGIN }}
+          registry_token: ${{ secrets.REGISTRY_TOKEN }}
+          dockerfile: "Dockerfile"
+          version: 1
+          tag: fedora
+```

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,129 @@
+name: 'Build and push images to registry'
+description: 'This GitHub Action builds a container image and pushes it to the specified registry.'
+author: 'RHSCL team'
+branding:
+  icon: circle
+  color: blue
+
+inputs:
+  registry:
+    description: 'Registry to push container image to'
+    required: true
+  registry_namespace:
+    description: 'Namespace of the registry, where the image would be pushed'
+    required: true
+  registry_username:
+    description: 'Login to specified registry'
+    required: true
+  registry_token:
+    description: 'Token to access the specified registry'
+    required: true
+  version:
+    description: 'Version of the built image'
+    required: true
+  tag:
+    description: 'Tag of the built image'
+    required: true
+  dockerfile:
+    description: 'Dockerfile to build the image'
+    required: false
+    default: 'Dockerfile'
+  docker_context:
+    description: 'Docker build context'
+    required: false
+    default: '.'
+  use_distgen:
+    description: 'The action will use distgen for generating dockerfiles if true'
+    required: false
+    default: 'false'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check if Action is run from sclorg repository
+      if: github.repository_owner != 'sclorg'
+      shell: bash
+      run: |
+        echo "This action can be run only for sclorg repositories"
+        exit 1
+
+    - name: Checkout git
+      uses: actions/checkout@v2
+      with:
+       submodules: true
+
+    - name: Get base image name
+      id: base-image-name
+      shell: bash
+      run: |
+        # This command returns row with BASE_IMAGE_NAME
+        row=$(grep "BASE_IMAGE_NAME" Makefile)
+        # Return only base image name
+        BASE_IMAGE_ROW=${row/BASE_IMAGE_NAME = /}
+        echo ::set-output name=image_name::$BASE_IMAGE_ROW
+
+    - name: Get short version
+      id: short_version
+      shell: bash
+      run: |
+        ver="${{ inputs.version }}"
+        echo "::set-output name=SHORT_VER::${ver//./}"
+
+    - name: Check if .exclude-${{ inputs.tag }} is present in version directory
+      id: check_exclude_file
+      # https://github.com/marketplace/actions/file-existence
+      uses: andstor/file-existence-action@v1
+      with:
+        files: "${{ inputs.version }}/.exclude-${{ inputs.tag }}"
+
+    - name: Login to registry
+      if: steps.check_exclude_file.outputs.files_exists == 'false'
+      uses: redhat-actions/podman-login@v1
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.registry_username }}
+        password: ${{ inputs.registry_token }}
+
+    - name: Install distgen and generate source
+      if: ${{ inputs.use_distgen }} == 'true' && steps.check_exclude_file.outputs.files_exists == 'false'
+      shell: bash
+      run: |
+        sudo apt-get update -y && sudo apt-get install -y python3 python3-pip
+        pip3 -v install distgen
+        DG=$HOME/.local/bin/dg make generate-all
+
+    - name: Check if ${{ inputs.dockerfile }} is present in version directory
+      if: steps.check_exclude_file.outputs.files_exists == 'false'
+      id: check_dockerfile_file
+      # https://github.com/marketplace/actions/file-existence
+      uses: andstor/file-existence-action@v1
+      with:
+        files: "${{ inputs.version }}/${{ inputs.dockerfile }}"
+        allow_failure: true # fails the Action if Dockerfile is missing
+
+    - name: Build image
+      if: steps.check_exclude_file.outputs.files_exists == 'false'
+      id: build-image
+      # https://github.com/marketplace/actions/buildah-build
+      uses: redhat-actions/buildah-build@v2
+      with:
+        dockerfiles: ${{ inputs.version }}/${{ inputs.dockerfile }}
+        image: ${{ steps.base-image-name.outputs.image_name}}-${{ steps.short_version.outputs.SHORT_VER }}-${{ inputs.tag }}
+        context: ${{ inputs.docker_context }}
+        tags: latest ${{ inputs.tag }} ${{ github.sha }}
+
+    - name: Push image to Quay.io/${{ inputs.registry_namespace }} namespace
+      if: steps.check_exclude_file.outputs.files_exists == 'false'
+      id: push-to-registry
+      uses: redhat-actions/push-to-registry@v2.2
+      with:
+        image: ${{ steps.build-image.outputs.image }}
+        tags: ${{ steps.build-image.outputs.tags }}
+        registry: quay.io/${{ inputs.registry_namespace }}
+        username: ${{ inputs.registry_username }}
+        password: ${{ inputs.registry_token }}
+
+    - name: Print image url
+      if: steps.check_exclude_file.outputs.files_exists == 'false'
+      shell: bash
+      run: echo "Image pushed to ${{ steps.push-to-registry.outputs.registry-paths }}"

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: 'Token to access the specified registry'
     required: true
   version:
-    description: 'Version of the built image'
+    description: 'Version of the primary application contained in the container image'
     required: true
   tag:
     description: 'Tag of the built image'

--- a/action.yml
+++ b/action.yml
@@ -69,15 +69,7 @@ runs:
         ver="${{ inputs.version }}"
         echo "::set-output name=SHORT_VER::${ver//./}"
 
-    - name: Check if .exclude-${{ inputs.tag }} is present in version directory
-      id: check_exclude_file
-      # https://github.com/marketplace/actions/file-existence
-      uses: andstor/file-existence-action@v1
-      with:
-        files: "${{ inputs.version }}/.exclude-${{ inputs.tag }}"
-
     - name: Login to registry
-      if: steps.check_exclude_file.outputs.files_exists == 'false'
       uses: redhat-actions/podman-login@v1
       with:
         registry: ${{ inputs.registry }}
@@ -85,12 +77,19 @@ runs:
         password: ${{ inputs.registry_token }}
 
     - name: Install distgen and generate source
-      if: ${{ inputs.use_distgen }} == 'true' && steps.check_exclude_file.outputs.files_exists == 'false'
+      if: ${{ inputs.use_distgen }} == 'true'
       shell: bash
       run: |
         sudo apt-get update -y && sudo apt-get install -y python3 python3-pip
         pip3 -v install distgen
         DG=$HOME/.local/bin/dg make generate-all
+
+    - name: Check if .exclude-${{ inputs.tag }} is present in version directory
+      id: check_exclude_file
+      # https://github.com/marketplace/actions/file-existence
+      uses: andstor/file-existence-action@v1
+      with:
+        files: "${{ inputs.version }}/.exclude-${{ inputs.tag }}"
 
     - name: Check if ${{ inputs.dockerfile }} is present in version directory
       if: steps.check_exclude_file.outputs.files_exists == 'false'

--- a/action.yml
+++ b/action.yml
@@ -118,7 +118,7 @@ runs:
       with:
         image: ${{ steps.build-image.outputs.image }}
         tags: ${{ steps.build-image.outputs.tags }}
-        registry: quay.io/${{ inputs.registry_namespace }}
+        registry: ${{ inputs.registry }}/${{ inputs.registry_namespace }}
         username: ${{ inputs.registry_username }}
         password: ${{ inputs.registry_token }}
 


### PR DESCRIPTION
This PR introduces build-and-push as a separated GitHub Action.

The action builds a specified container image and pushes it to a specified container registry.

The action is aiming to be generic but used only for the sclorg repositories, which is forced with used conditional.


