### PR TITLE
Move release tag from v*.*.* to v1 automaticaly

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,33 @@
+# Source: https://github.com/release-drafter/release-drafter/blob/master/.github/workflows/release.yml
+---
+
+name: Release
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Version
+        id: version
+        run: |
+          tag=${GITHUB_REF/refs\/tags\//}
+          version=${tag#v}
+          major=${version%%.*}
+          echo "::set-output name=tag::${tag}"
+          echo "::set-output name=version::${version}"
+          echo "::set-output name=major::${major}"
+
+      - name: force update major tag
+        run: |
+          git tag v${{ steps.version.outputs.major }} ${{ steps.version.outputs.tag }} -f
+          git push origin refs/tags/v${{ steps.version.outputs.major }} -f

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - name: Version
         id: version
@@ -29,5 +27,6 @@ jobs:
 
       - name: force update major tag
         run: |
+          # Move that tag to the latest 'major' version, like 'v1', 'v2' in the future etc.
           git tag v${{ steps.version.outputs.major }} ${{ steps.version.outputs.tag }} -f
           git push origin refs/tags/v${{ steps.version.outputs.major }} -f


### PR DESCRIPTION
See similar approach which we already have in `testing-farm-as-a-github-action`.
https://github.com/sclorg/testing-farm-as-github-action/blob/main/.github/workflows/publish-release.yml

As soon as the new release is published then the tag is automatically moved into the release tag as @v1.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>