### PR TITLE
tag input is not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ registry/registry_namespace/image_name
 | Input Name | Description | Default value |
 |------------|-------------|---------------|
 | `image_name` | Name of the built image. | **required** |
-| `tag` | Tag of the built image. | **required** |
+| `tag` | Tag of the built image. | "" |
 | `dockerfile` | Dockerfile and its relative path to build the image. | Dockerfile |
 | `use_distgen` | The action will use distgen for generating dockerfiles if true. | false |
 | `docker_context` | Docker build context. | . |

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,8 @@ inputs:
     required: true
   tag:
     description: 'Tag of the built image'
-    required: true
+    required: false
+    default: ''
   dockerfile:
     description: 'Dockerfile to build the image with a relative path'
     required: false


### PR DESCRIPTION
Setting input tag as not required, because we already mark built image
with following tags:
  - latest
  - current date
  - github sha

I can imagine, that for some container are these tags just enough.