### PR TITLE
removing distgen generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ registry/registry_namespace/image_name
 | `image_name` | Name of the built image. | **required** |
 | `tag` | Tag of the built image. | "" |
 | `dockerfile` | Dockerfile and its relative path to build the image. | Dockerfile |
-| `use_distgen` | The action will use distgen for generating dockerfiles if true. | false |
 | `docker_context` | Docker build context. | . |
 
 

--- a/action.yml
+++ b/action.yml
@@ -33,10 +33,6 @@ inputs:
     description: 'Docker build context'
     required: false
     default: '.'
-  use_distgen:
-    description: 'The action will use distgen for generating dockerfiles if true'
-    required: false
-    default: 'false'
 
 runs:
   using: "composite"
@@ -64,14 +60,6 @@ runs:
         echo "::set-output name=cur_date::$(date +'%Y%m%d')"
         echo "::set-output name=dockerfile_path::${tmp%/*}"
         echo "::set-output name=distribution::${distribution}"
-
-    - name: Install distgen and generate source
-      if: ${{ inputs.use_distgen == 'true' }}
-      shell: bash
-      run: |
-        sudo apt-get update -y && sudo apt-get install -y python3 python3-pip
-        pip3 -v install distgen
-        DG=$HOME/.local/bin/dg make generate-all
 
     # exclusion mechanism.
     # when .exlude-<distribution> file in Dockerfile folder exists,


### PR DESCRIPTION
The files should be already properly generated before running this action.
This change is not backward compatible.

resolves: https://github.com/sclorg/build-and-push-action/issues/19