### PR TITLE
use bash for running python

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -145,8 +145,8 @@ runs:
         IMAGE_NAME: ${{ inputs.image_name}}
         REGISTRY_NAMESPACE: ${{ inputs.registry_namespace }}
         README_PATH: ${{ inputs.readme }}
-      run: update_quay_description.py
-      shell: python
+      run: python update_quay_description.py
+      shell: bash
 
     - name: Print image url
       if: steps.check_exclude_file.outputs.files_exists == 'false'


### PR DESCRIPTION
Fixes "NameError: name 'update_quay_description' is not defined".

Tested on my fork.