### PR TITLE
Do not logout from job at the end

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,7 @@ runs:
         registry: ${{ inputs.registry }}
         username: ${{ inputs.registry_username }}
         password: ${{ inputs.registry_token }}
+        logout: false
 
     - name: Checkout git
       uses: actions/checkout@v4


### PR DESCRIPTION
In case s2i-base container is logout at the end by podman, than s2i-core container failed by logout.
